### PR TITLE
Add a publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to RubyGems
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.1
+
+      - name: Build Gem
+        run: gem build -o patch_ruby.gem patch_ruby.gemspec
+
+      - name: Push to RubyGems
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
+        run: gem push patch_ruby.gem
+


### PR DESCRIPTION
- Publishes the Gem to RubyGems on the creation of a new release

TODO
- [x] Create a RubyGems account
- [x] Add the RubyGems key to a secret, `GEM_HOST_API_KEY`, on this repo