### PR TITLE
Updates after post-mortem

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+### What
+
+** CHANGEME: What are you changing? **
+
+### Why
+
+** CHANGEME: Why are these changes needed? **
+
+### SDK Release Checklist
+
+- [ ] Have you added an integration test for the changes?
+- [ ] Have you built the gem locally and made queries against it successfully?

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Build Gem
         run: gem build -o patch_ruby.gem patch_ruby.gemspec
 
+      - name: Run RSpec
+        env:
+          PATCH_RUBY_API_KEY: ${{ secrets.SANDBOX_API_KEY }}
+        run: bundle exec rspec
+
       - name: Push to RubyGems
         env:
           GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install Ruby Dependencies
         run: bundle install
 
+      - name: Build Gem
+        run: gem build -o patch_ruby.gem patch_ruby.gemspec
+
       - name: Run RSpec
         env:
           PATCH_RUBY_API_KEY: ${{ secrets.SANDBOX_API_KEY }}


### PR DESCRIPTION
- Added support for building the ruby gem before running tests 
- Added support for running the specs before releasing the gem 
- Added a PR template to remind authors of adding tests and building the gem locally and running queries against it successfully 