### PR TITLE
Build gem and run specs once a day

### DIFF
--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -1,0 +1,41 @@
+name: Health check
+on:
+  schedule:
+    - cron: '0 9 * * * America/Los_Angeles'
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.1
+
+      - name: Install Ruby Dependencies
+        run: bundle install
+
+      - name: Build Gem
+        run: gem build -o patch_ruby.gem patch_ruby.gemspec
+
+      - name: Run RSpec
+        env:
+          PATCH_RUBY_API_KEY: ${{ secrets.SANDBOX_API_KEY }}
+        run: bundle exec rspec
+
+  failure-notification:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: exit 1
+      - name: Health check failure
+        if: always()
+        uses: kpritam/slack-job-status-action@v1
+        with:
+          job-status: ${{ job.status }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel: github-actions


### PR DESCRIPTION
### What

- Building the package and running the tests once a day 
- Alerting in slack if the job fails

### Why

So that we catch drifts between our API and the SDK's early and often. 

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the gem locally and made queries against it successfully?
