### PR TITLE
Run at 5pm UTC

### DIFF
--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -1,7 +1,7 @@
 name: Health check
 on:
   schedule:
-    - cron: '0 9 * * * America/Los_Angeles'
+    - cron: '0 17 * * *'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
### What

Do not use the timezone and instead use UTC. 

### Why

We want to run the specs at 9 am PT every day.

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the gem locally and made queries against it successfully?
