### PR TITLE
order price creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.3] - 2020-09-28
+## [1.2.4] - 2020-10-14
+
+### Added
+
+- `total_price_cents_usd` field to `orders`
+- allows users to create an order by total price
+
+### Changed
+
+- order creation requires either `mass_g` or `total_price_cents_usd`, but not both
+
+## [1.2.3] - 2020-10-05
 
 ### Added
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patch_ruby (1.2.3)
+    patch_ruby (1.2.4)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ In Patch, orders represent a purchase of carbon offsets or negative emissions by
 mass = 1_000_000 # Pass in the mass in grams (i.e. 1 metric tonne)
 Patch::Order.create_order(mass_g: mass)
 
+# Create an order with maximum total price
+total_price_cents_usd = 5_00 # Pass in the total price in cents (i.e. 5 dollars)
+Patch::Order.create_order(total_price_cents_usd: total_price_cents_usd)
+
 ## You can also specify a project-id field (optional) to be used instead of the preferred one
 project_id = 'pro_test_1234' # Pass in the project's ID
 Patch::Order.create_order(mass_g: mass, project_id: project_id)

--- a/README.md
+++ b/README.md
@@ -45,11 +45,20 @@ end
 ### Orders
 In Patch, orders represent a purchase of carbon offsets or negative emissions by mass. Place orders directly if you know the amount of carbon dioxide you would like to sequester. If you do not know how much to purchase, use an estimate.
 
+In Patch, orders represent a purchase of carbon offsets or negative emissions by mass.
+Place orders directly if you know the amount of carbon dioxide you would like to sequester.
+If you do not know how much to purchase, use an estimate.
+You can also create an order with a maximum desired price, and we'll allocate enough mass to
+fulfill the order for you.
+
 [API Reference](https://docs.usepatch.com/#/?id=orders)
 
 #### Examples
 ```ruby
-# Create an order
+# Create an order - you can create an order
+# providing either mass_g or total_price_cents_usd, but not both
+
+# Create order with mass
 mass = 1_000_000 # Pass in the mass in grams (i.e. 1 metric tonne)
 Patch::Order.create_order(mass_g: mass)
 

--- a/lib/patch_ruby/models/create_order_request.rb
+++ b/lib/patch_ruby/models/create_order_request.rb
@@ -16,6 +16,8 @@ module Patch
   class CreateOrderRequest
     attr_accessor :mass_g
 
+    attr_accessor :total_price_cents_usd
+
     attr_accessor :project_id
 
     attr_accessor :metadata
@@ -24,6 +26,7 @@ module Patch
     def self.attribute_map
       {
         :'mass_g' => :'mass_g',
+        :'total_price_cents_usd' => :'total_price_cents_usd',
         :'project_id' => :'project_id',
         :'metadata' => :'metadata'
       }
@@ -33,6 +36,7 @@ module Patch
     def self.openapi_types
       {
         :'mass_g' => :'Integer',
+        :'total_price_cents_usd' => :'Integer',
         :'project_id' => :'String',
         :'metadata' => :'Object'
       }
@@ -68,6 +72,10 @@ module Patch
         self.mass_g = attributes[:'mass_g']
       end
 
+      if attributes.key?(:'total_price_cents_usd')
+        self.total_price_cents_usd = attributes[:'total_price_cents_usd']
+      end
+
       if attributes.key?(:'project_id')
         self.project_id = attributes[:'project_id']
       end
@@ -81,16 +89,16 @@ module Patch
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       invalid_properties = Array.new
-      if @mass_g.nil?
-        invalid_properties.push('invalid value for "mass_g", mass_g cannot be nil.')
-      end
-
-      if @mass_g > 2000000000
+      if !@mass_g.nil? && @mass_g > 2000000000
         invalid_properties.push('invalid value for "mass_g", must be smaller than or equal to 2000000000.')
       end
 
-      if @mass_g < 1
+      if !@mass_g.nil? && @mass_g < 1
         invalid_properties.push('invalid value for "mass_g", must be greater than or equal to 1.')
+      end
+
+      if !@total_price_cents_usd.nil? && @total_price_cents_usd < 1
+        invalid_properties.push('invalid value for "total_price_cents_usd", must be greater than or equal to 1.')
       end
 
       invalid_properties
@@ -99,28 +107,34 @@ module Patch
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      return false if @mass_g.nil?
-      return false if @mass_g > 2000000000
-      return false if @mass_g < 1
+      return false if !@mass_g.nil? && @mass_g > 2000000000
+      return false if !@mass_g.nil? && @mass_g < 1
+      return false if !@total_price_cents_usd.nil? && @total_price_cents_usd < 1
       true
     end
 
     # Custom attribute writer method with validation
     # @param [Object] mass_g Value to be assigned
     def mass_g=(mass_g)
-      if mass_g.nil?
-        fail ArgumentError, 'mass_g cannot be nil'
-      end
-
-      if mass_g > 2000000000
+      if !mass_g.nil? && mass_g > 2000000000
         fail ArgumentError, 'invalid value for "mass_g", must be smaller than or equal to 2000000000.'
       end
 
-      if mass_g < 1
+      if !mass_g.nil? && mass_g < 1
         fail ArgumentError, 'invalid value for "mass_g", must be greater than or equal to 1.'
       end
 
       @mass_g = mass_g
+    end
+
+    # Custom attribute writer method with validation
+    # @param [Object] total_price_cents_usd Value to be assigned
+    def total_price_cents_usd=(total_price_cents_usd)
+      if !total_price_cents_usd.nil? && total_price_cents_usd < 1
+        fail ArgumentError, 'invalid value for "total_price_cents_usd", must be greater than or equal to 1.'
+      end
+
+      @total_price_cents_usd = total_price_cents_usd
     end
 
     # Checks equality by comparing each attribute.
@@ -129,6 +143,7 @@ module Patch
       return true if self.equal?(o)
       self.class == o.class &&
           mass_g == o.mass_g &&
+          total_price_cents_usd == o.total_price_cents_usd &&
           project_id == o.project_id &&
           metadata == o.metadata
     end
@@ -142,7 +157,7 @@ module Patch
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [mass_g, project_id, metadata].hash
+      [mass_g, total_price_cents_usd, project_id, metadata].hash
     end
 
     # Builds the object from hash

--- a/lib/patch_ruby/version.rb
+++ b/lib/patch_ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 4.3.1
 =end
 
 module Patch
-  VERSION = '1.2.3'
+  VERSION = '1.2.4'
 end

--- a/spec/integration/orders_spec.rb
+++ b/spec/integration/orders_spec.rb
@@ -47,6 +47,32 @@ RSpec.describe 'Orders Integration' do
     expect(create_order_response.data.patch_fee_cents_usd).not_to be_empty
   end
 
+  it 'supports create with a total price' do
+    retrieve_project_response = Patch::Project.retrieve_project(
+      Constants::BIOMASS_TEST_PROJECT_ID
+    )
+
+    project_id = retrieve_project_response.data.id
+    total_price_cents_usd = 5_00
+
+    create_order_response = Patch::Order.create_order(
+      total_price_cents_usd: total_price_cents_usd,
+      project_id: project_id
+    )
+
+    expect(create_order_response.success).to eq true
+
+    order = create_order_response.data
+
+    expect(order.id).not_to be_nil
+    expect(order.mass_g).to eq(1_250_000)
+    expect(order.price_cents_usd.to_i).to eq(125)
+    expect(order.patch_fee_cents_usd.to_i).to eq(375)
+    expect(
+      order.price_cents_usd.to_i + order.patch_fee_cents_usd.to_i
+    ).to eq(total_price_cents_usd)
+  end
+
   it 'supports create with metadata' do
     metadata = { user: 'john doe' }
 

--- a/spec/integration/orders_spec.rb
+++ b/spec/integration/orders_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe 'Orders Integration' do
     order = create_order_response.data
 
     expect(order.id).not_to be_nil
-    expect(order.mass_g).to eq(1_250_000)
-    expect(order.price_cents_usd.to_i).to eq(125)
-    expect(order.patch_fee_cents_usd.to_i).to eq(375)
+    expect(order.mass_g).to eq(5_000_000)
+    expect(order.price_cents_usd.to_i).to eq(500)
+    expect(order.patch_fee_cents_usd).not_to be_empty
     expect(
       order.price_cents_usd.to_i + order.patch_fee_cents_usd.to_i
     ).to eq(total_price_cents_usd)


### PR DESCRIPTION
### What

- adds field `total_price_cents_usd` to order creation
- allows user to create order by passing `mass_g` or `total_price_cents_usd`, but not both

### Why

- to allow users to create orders by a desired total amount

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the gem locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [x] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
