### PR TITLE
[v1.3.0] Add Flight/Shipping/Vehicle estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.5] - 2021-02-08
+## [1.3.0] - 2021-02-08
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.6] - 2021-02-08
+## [1.3.5] - 2021-02-08
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.6] - 2021-02-08
+
+### Added
+
+- Adds support for creating carbon emission estimates for flights, shipping, and vehicles. See the [docs](https://docs.usepatch.com/#/?id=estimates) for more information.
 
 ## [1.2.5] - 2020-01-08
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patch_ruby (1.3.5)
+    patch_ruby (1.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patch_ruby (1.2.6)
+    patch_ruby (1.3.5)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patch_ruby (1.2.5)
+    patch_ruby (1.2.6)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,35 @@ Estimates allow API users to get a quote for the cost of compensating a certain 
 
 #### Examples
 ```ruby
-# Create an estimate
+# Create a mass estimate
 mass = 1_000_000 # Pass in the mass in grams (i.e. 1 metric tonne)
 Patch::Estimate.create_mass_estimate(mass_g: mass)
+
+# Create a flight estimate
+distance_m = 1_000_000 # Pass in the distance traveled in meters
+Patch::Estimate.create_flight_estimate(distance_m: distance_m)
+
+# Create a shipping estimate
+distance_m = 1_000_000 # Pass in the shipping distance in meters
+package_mass_g = 10_000 # Pass in the weight of the package shipped in grams
+transportation_method = "air" # Pass in the transportation method (air, rail, road, sea)
+Patch::Estimate.create_shipping_estimate(
+  distance_m: distance_m,
+  package_mass_g: package_mass_g,
+  transportation_method: transportation_method
+)
+
+# Create a vehicle estimate
+distance_m = 1_000_000 # Pass in the shipping distance in meters
+make = "Toyota" # Pass in the car make
+model = "Corolla" # Pass in the car model
+year = 2000 # Pass in the car year
+Patch::Estimate.create_vehicle_estimate(
+  distance_m: distance_m,
+  make: make,
+  model: model,
+  year: year
+)
 
 ## You can also specify a project-id field (optional) to be used instead of the preferred one
 project_id = 'pro_test_1234' # Pass in the project's ID

--- a/lib/patch_ruby/api/estimates_api.rb
+++ b/lib/patch_ruby/api/estimates_api.rb
@@ -15,7 +15,10 @@ require 'cgi'
 module Patch
   class EstimatesApi
     OPERATIONS = [
+      :create_flight_estimate,
       :create_mass_estimate,
+      :create_shipping_estimate,
+      :create_vehicle_estimate,
       :retrieve_estimate,
       :retrieve_estimates,
     ]
@@ -25,6 +28,70 @@ module Patch
     def initialize(api_client = ApiClient.default)
       @api_client = api_client
     end
+    # Create a flight estimate given the distance traveled in meters
+    # Creates a flight estimate for the amount of CO2 to be compensated. An order in the `draft` state may be created based on the parameters, linked to the estimate. 
+    # @param create_flight_estimate_request [CreateFlightEstimateRequest] 
+    # @param [Hash] opts the optional parameters
+    # @return [EstimateResponse]
+    def create_flight_estimate(create_flight_estimate_request, opts = {})
+      data, _status_code, _headers = create_flight_estimate_with_http_info(create_flight_estimate_request, opts)
+      data
+    end
+
+    # Create a flight estimate given the distance traveled in meters
+    # Creates a flight estimate for the amount of CO2 to be compensated. An order in the &#x60;draft&#x60; state may be created based on the parameters, linked to the estimate. 
+    # @param create_flight_estimate_request [CreateFlightEstimateRequest] 
+    # @param [Hash] opts the optional parameters
+    # @return [Array<(EstimateResponse, Integer, Hash)>] EstimateResponse data, response status code and response headers
+    def create_flight_estimate_with_http_info(create_flight_estimate_request, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: EstimatesApi.create_flight_estimate ...'
+      end
+      # verify the required parameter 'create_flight_estimate_request' is set
+      if @api_client.config.client_side_validation && create_flight_estimate_request.nil?
+        fail ArgumentError, "Missing the required parameter 'create_flight_estimate_request' when calling EstimatesApi.create_flight_estimate"
+      end
+      # resource path
+      local_var_path = '/v1/estimates/flight'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      # HTTP header 'Content-Type'
+      header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:body] || @api_client.object_to_http_body(create_flight_estimate_request) 
+
+      # return_type
+      return_type = opts[:return_type] || 'EstimateResponse' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['bearer_auth']
+
+      new_options = opts.merge(
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: EstimatesApi#create_flight_estimate\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
     # Create an estimate based on mass of CO2
     # Creates an estimate for the mass of CO2 to be compensated. An order in the `draft` state will also be created, linked to the estimate. 
     # @param create_mass_estimate_request [CreateMassEstimateRequest] 
@@ -85,6 +152,134 @@ module Patch
       data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: EstimatesApi#create_mass_estimate\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
+    # Create a shipping estimate given the distance traveled in meters, package weight, and transportation method.
+    # Creates a shipping estimate for the amount of CO2 to be compensated. An order in the `draft` state may be created based on the parameters. 
+    # @param create_shipping_estimate_request [CreateShippingEstimateRequest] 
+    # @param [Hash] opts the optional parameters
+    # @return [EstimateResponse]
+    def create_shipping_estimate(create_shipping_estimate_request, opts = {})
+      data, _status_code, _headers = create_shipping_estimate_with_http_info(create_shipping_estimate_request, opts)
+      data
+    end
+
+    # Create a shipping estimate given the distance traveled in meters, package weight, and transportation method.
+    # Creates a shipping estimate for the amount of CO2 to be compensated. An order in the &#x60;draft&#x60; state may be created based on the parameters. 
+    # @param create_shipping_estimate_request [CreateShippingEstimateRequest] 
+    # @param [Hash] opts the optional parameters
+    # @return [Array<(EstimateResponse, Integer, Hash)>] EstimateResponse data, response status code and response headers
+    def create_shipping_estimate_with_http_info(create_shipping_estimate_request, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: EstimatesApi.create_shipping_estimate ...'
+      end
+      # verify the required parameter 'create_shipping_estimate_request' is set
+      if @api_client.config.client_side_validation && create_shipping_estimate_request.nil?
+        fail ArgumentError, "Missing the required parameter 'create_shipping_estimate_request' when calling EstimatesApi.create_shipping_estimate"
+      end
+      # resource path
+      local_var_path = '/v1/estimates/shipping'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      # HTTP header 'Content-Type'
+      header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:body] || @api_client.object_to_http_body(create_shipping_estimate_request) 
+
+      # return_type
+      return_type = opts[:return_type] || 'EstimateResponse' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['bearer_auth']
+
+      new_options = opts.merge(
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: EstimatesApi#create_shipping_estimate\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
+    # Create a vehicle estimate given the distance traveled in meters and the type of vehicle
+    # Creates an estimate and calculates the amount of CO2 to be compensated depending on the distance and the vehicle. An order in the `draft` state may be created based on the parameters, linked to the estimate. 
+    # @param create_vehicle_estimate_request [CreateVehicleEstimateRequest] 
+    # @param [Hash] opts the optional parameters
+    # @return [EstimateResponse]
+    def create_vehicle_estimate(create_vehicle_estimate_request, opts = {})
+      data, _status_code, _headers = create_vehicle_estimate_with_http_info(create_vehicle_estimate_request, opts)
+      data
+    end
+
+    # Create a vehicle estimate given the distance traveled in meters and the type of vehicle
+    # Creates an estimate and calculates the amount of CO2 to be compensated depending on the distance and the vehicle. An order in the &#x60;draft&#x60; state may be created based on the parameters, linked to the estimate. 
+    # @param create_vehicle_estimate_request [CreateVehicleEstimateRequest] 
+    # @param [Hash] opts the optional parameters
+    # @return [Array<(EstimateResponse, Integer, Hash)>] EstimateResponse data, response status code and response headers
+    def create_vehicle_estimate_with_http_info(create_vehicle_estimate_request, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: EstimatesApi.create_vehicle_estimate ...'
+      end
+      # verify the required parameter 'create_vehicle_estimate_request' is set
+      if @api_client.config.client_side_validation && create_vehicle_estimate_request.nil?
+        fail ArgumentError, "Missing the required parameter 'create_vehicle_estimate_request' when calling EstimatesApi.create_vehicle_estimate"
+      end
+      # resource path
+      local_var_path = '/v1/estimates/vehicle'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      # HTTP header 'Content-Type'
+      header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:body] || @api_client.object_to_http_body(create_vehicle_estimate_request) 
+
+      # return_type
+      return_type = opts[:return_type] || 'EstimateResponse' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['bearer_auth']
+
+      new_options = opts.merge(
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: EstimatesApi#create_vehicle_estimate\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end

--- a/lib/patch_ruby/api/preferences_api.rb
+++ b/lib/patch_ruby/api/preferences_api.rb
@@ -27,8 +27,8 @@ module Patch
       @api_client = api_client
     end
     # creates a project preference
-    # Creates a project preference for the given organization. If you have a `preference` in place, all of your orders will be directed to the project the preference points to.
-    # @param create_preference_request [CreatePreferenceRequest]
+    # Creates a project preference for the given organization. If you have a `preference` in place, all of your orders will be directed to the project the preference points to. 
+    # @param create_preference_request [CreatePreferenceRequest] 
     # @param [Hash] opts the optional parameters
     # @return [PreferenceResponse]
     def create_preference(create_preference_request, opts = {})
@@ -37,8 +37,8 @@ module Patch
     end
 
     # creates a project preference
-    # Creates a project preference for the given organization. If you have a &#x60;preference&#x60; in place, all of your orders will be directed to the project the preference points to.
-    # @param create_preference_request [CreatePreferenceRequest]
+    # Creates a project preference for the given organization. If you have a &#x60;preference&#x60; in place, all of your orders will be directed to the project the preference points to. 
+    # @param create_preference_request [CreatePreferenceRequest] 
     # @param [Hash] opts the optional parameters
     # @return [Array<(PreferenceResponse, Integer, Hash)>] PreferenceResponse data, response status code and response headers
     def create_preference_with_http_info(create_preference_request, opts = {})
@@ -66,10 +66,10 @@ module Patch
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(create_preference_request)
+      post_body = opts[:body] || @api_client.object_to_http_body(create_preference_request) 
 
       # return_type
-      return_type = opts[:return_type] || 'PreferenceResponse'
+      return_type = opts[:return_type] || 'PreferenceResponse' 
 
       # auth_names
       auth_names = opts[:auth_names] || ['bearer_auth']
@@ -91,8 +91,8 @@ module Patch
     end
 
     # Deletes an organization's preference for a project
-    # Deletes the given `preference`. Once a preference is deleted, it cannot be undone. If you want to restore your previous preference, create a new one.
-    # @param id [String]
+    # Deletes the given `preference`. Once a preference is deleted, it cannot be undone. If you want to restore your previous preference, create a new one. 
+    # @param id [String] 
     # @param [Hash] opts the optional parameters
     # @return [PreferenceResponse]
     def delete_preference(id, opts = {})
@@ -101,8 +101,8 @@ module Patch
     end
 
     # Deletes an organization&#39;s preference for a project
-    # Deletes the given &#x60;preference&#x60;. Once a preference is deleted, it cannot be undone. If you want to restore your previous preference, create a new one.
-    # @param id [String]
+    # Deletes the given &#x60;preference&#x60;. Once a preference is deleted, it cannot be undone. If you want to restore your previous preference, create a new one. 
+    # @param id [String] 
     # @param [Hash] opts the optional parameters
     # @return [Array<(PreferenceResponse, Integer, Hash)>] PreferenceResponse data, response status code and response headers
     def delete_preference_with_http_info(id, opts = {})
@@ -128,10 +128,10 @@ module Patch
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body]
+      post_body = opts[:body] 
 
       # return_type
-      return_type = opts[:return_type] || 'PreferenceResponse'
+      return_type = opts[:return_type] || 'PreferenceResponse' 
 
       # auth_names
       auth_names = opts[:auth_names] || ['bearer_auth']
@@ -153,8 +153,8 @@ module Patch
     end
 
     # Retrieve the preference
-    # Retrieve the preference and project of an organization. You can only retrieve preferences associated with your organization.
-    # @param id [String]
+    # Retrieve the preference and project of an organization. You can only retrieve preferences associated with your organization. 
+    # @param id [String] 
     # @param [Hash] opts the optional parameters
     # @return [PreferenceResponse]
     def retrieve_preference(id, opts = {})
@@ -163,8 +163,8 @@ module Patch
     end
 
     # Retrieve the preference
-    # Retrieve the preference and project of an organization. You can only retrieve preferences associated with your organization.
-    # @param id [String]
+    # Retrieve the preference and project of an organization. You can only retrieve preferences associated with your organization. 
+    # @param id [String] 
     # @param [Hash] opts the optional parameters
     # @return [Array<(PreferenceResponse, Integer, Hash)>] PreferenceResponse data, response status code and response headers
     def retrieve_preference_with_http_info(id, opts = {})
@@ -190,10 +190,10 @@ module Patch
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body]
+      post_body = opts[:body] 
 
       # return_type
-      return_type = opts[:return_type] || 'PreferenceResponse'
+      return_type = opts[:return_type] || 'PreferenceResponse' 
 
       # auth_names
       auth_names = opts[:auth_names] || ['bearer_auth']
@@ -215,9 +215,9 @@ module Patch
     end
 
     # Retrieves a list of preferences
-    # Retrieves a list of preferences and associated projects of an organization. You can only retrieve preferences associated with your organization.
+    # Retrieves a list of preferences and associated projects of an organization. You can only retrieve preferences associated with your organization. 
     # @param [Hash] opts the optional parameters
-    # @option opts [Integer] :page
+    # @option opts [Integer] :page 
     # @return [PreferenceListResponse]
     def retrieve_preferences(opts = {})
       data, _status_code, _headers = retrieve_preferences_with_http_info(opts)
@@ -225,9 +225,9 @@ module Patch
     end
 
     # Retrieves a list of preferences
-    # Retrieves a list of preferences and associated projects of an organization. You can only retrieve preferences associated with your organization.
+    # Retrieves a list of preferences and associated projects of an organization. You can only retrieve preferences associated with your organization. 
     # @param [Hash] opts the optional parameters
-    # @option opts [Integer] :page
+    # @option opts [Integer] :page 
     # @return [Array<(PreferenceListResponse, Integer, Hash)>] PreferenceListResponse data, response status code and response headers
     def retrieve_preferences_with_http_info(opts = {})
       if @api_client.config.debugging
@@ -249,10 +249,10 @@ module Patch
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body]
+      post_body = opts[:body] 
 
       # return_type
-      return_type = opts[:return_type] || 'PreferenceListResponse'
+      return_type = opts[:return_type] || 'PreferenceListResponse' 
 
       # auth_names
       auth_names = opts[:auth_names] || ['bearer_auth']

--- a/lib/patch_ruby/api/preferences_api.rb
+++ b/lib/patch_ruby/api/preferences_api.rb
@@ -27,8 +27,8 @@ module Patch
       @api_client = api_client
     end
     # creates a project preference
-    # Creates a project preference for the given organization. If you have a `preference` in place, all of your orders will be directed to the project the preference points to. 
-    # @param create_preference_request [CreatePreferenceRequest] 
+    # Creates a project preference for the given organization. If you have a `preference` in place, all of your orders will be directed to the project the preference points to.
+    # @param create_preference_request [CreatePreferenceRequest]
     # @param [Hash] opts the optional parameters
     # @return [PreferenceResponse]
     def create_preference(create_preference_request, opts = {})
@@ -37,8 +37,8 @@ module Patch
     end
 
     # creates a project preference
-    # Creates a project preference for the given organization. If you have a &#x60;preference&#x60; in place, all of your orders will be directed to the project the preference points to. 
-    # @param create_preference_request [CreatePreferenceRequest] 
+    # Creates a project preference for the given organization. If you have a &#x60;preference&#x60; in place, all of your orders will be directed to the project the preference points to.
+    # @param create_preference_request [CreatePreferenceRequest]
     # @param [Hash] opts the optional parameters
     # @return [Array<(PreferenceResponse, Integer, Hash)>] PreferenceResponse data, response status code and response headers
     def create_preference_with_http_info(create_preference_request, opts = {})
@@ -66,10 +66,10 @@ module Patch
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] || @api_client.object_to_http_body(create_preference_request) 
+      post_body = opts[:body] || @api_client.object_to_http_body(create_preference_request)
 
       # return_type
-      return_type = opts[:return_type] || 'PreferenceResponse' 
+      return_type = opts[:return_type] || 'PreferenceResponse'
 
       # auth_names
       auth_names = opts[:auth_names] || ['bearer_auth']
@@ -91,8 +91,8 @@ module Patch
     end
 
     # Deletes an organization's preference for a project
-    # Deletes the given `preference`. Once a preference is deleted, it cannot be undone. If you want to restore your previous preference, create a new one. 
-    # @param id [String] 
+    # Deletes the given `preference`. Once a preference is deleted, it cannot be undone. If you want to restore your previous preference, create a new one.
+    # @param id [String]
     # @param [Hash] opts the optional parameters
     # @return [PreferenceResponse]
     def delete_preference(id, opts = {})
@@ -101,8 +101,8 @@ module Patch
     end
 
     # Deletes an organization&#39;s preference for a project
-    # Deletes the given &#x60;preference&#x60;. Once a preference is deleted, it cannot be undone. If you want to restore your previous preference, create a new one. 
-    # @param id [String] 
+    # Deletes the given &#x60;preference&#x60;. Once a preference is deleted, it cannot be undone. If you want to restore your previous preference, create a new one.
+    # @param id [String]
     # @param [Hash] opts the optional parameters
     # @return [Array<(PreferenceResponse, Integer, Hash)>] PreferenceResponse data, response status code and response headers
     def delete_preference_with_http_info(id, opts = {})
@@ -128,10 +128,10 @@ module Patch
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:body]
 
       # return_type
-      return_type = opts[:return_type] || 'PreferenceResponse' 
+      return_type = opts[:return_type] || 'PreferenceResponse'
 
       # auth_names
       auth_names = opts[:auth_names] || ['bearer_auth']
@@ -153,8 +153,8 @@ module Patch
     end
 
     # Retrieve the preference
-    # Retrieve the preference and project of an organization. You can only retrieve preferences associated with your organization. 
-    # @param id [String] 
+    # Retrieve the preference and project of an organization. You can only retrieve preferences associated with your organization.
+    # @param id [String]
     # @param [Hash] opts the optional parameters
     # @return [PreferenceResponse]
     def retrieve_preference(id, opts = {})
@@ -163,8 +163,8 @@ module Patch
     end
 
     # Retrieve the preference
-    # Retrieve the preference and project of an organization. You can only retrieve preferences associated with your organization. 
-    # @param id [String] 
+    # Retrieve the preference and project of an organization. You can only retrieve preferences associated with your organization.
+    # @param id [String]
     # @param [Hash] opts the optional parameters
     # @return [Array<(PreferenceResponse, Integer, Hash)>] PreferenceResponse data, response status code and response headers
     def retrieve_preference_with_http_info(id, opts = {})
@@ -190,10 +190,10 @@ module Patch
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:body]
 
       # return_type
-      return_type = opts[:return_type] || 'PreferenceResponse' 
+      return_type = opts[:return_type] || 'PreferenceResponse'
 
       # auth_names
       auth_names = opts[:auth_names] || ['bearer_auth']
@@ -215,9 +215,9 @@ module Patch
     end
 
     # Retrieves a list of preferences
-    # Retrieves a list of preferences and associated projects of an organization. You can only retrieve preferences associated with your organization. 
+    # Retrieves a list of preferences and associated projects of an organization. You can only retrieve preferences associated with your organization.
     # @param [Hash] opts the optional parameters
-    # @option opts [Integer] :page 
+    # @option opts [Integer] :page
     # @return [PreferenceListResponse]
     def retrieve_preferences(opts = {})
       data, _status_code, _headers = retrieve_preferences_with_http_info(opts)
@@ -225,9 +225,9 @@ module Patch
     end
 
     # Retrieves a list of preferences
-    # Retrieves a list of preferences and associated projects of an organization. You can only retrieve preferences associated with your organization. 
+    # Retrieves a list of preferences and associated projects of an organization. You can only retrieve preferences associated with your organization.
     # @param [Hash] opts the optional parameters
-    # @option opts [Integer] :page 
+    # @option opts [Integer] :page
     # @return [Array<(PreferenceListResponse, Integer, Hash)>] PreferenceListResponse data, response status code and response headers
     def retrieve_preferences_with_http_info(opts = {})
       if @api_client.config.debugging
@@ -249,10 +249,10 @@ module Patch
       form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = opts[:body] 
+      post_body = opts[:body]
 
       # return_type
-      return_type = opts[:return_type] || 'PreferenceListResponse' 
+      return_type = opts[:return_type] || 'PreferenceListResponse'
 
       # auth_names
       auth_names = opts[:auth_names] || ['bearer_auth']

--- a/lib/patch_ruby/models/create_mass_estimate_request.rb
+++ b/lib/patch_ruby/models/create_mass_estimate_request.rb
@@ -16,12 +16,15 @@ module Patch
   class CreateMassEstimateRequest
     attr_accessor :mass_g
 
+    attr_accessor :create_order
+
     attr_accessor :project_id
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         :'mass_g' => :'mass_g',
+        :'create_order' => :'create_order',
         :'project_id' => :'project_id'
       }
     end
@@ -30,6 +33,7 @@ module Patch
     def self.openapi_types
       {
         :'mass_g' => :'Integer',
+        :'create_order' => :'Boolean',
         :'project_id' => :'String'
       }
     end
@@ -37,6 +41,8 @@ module Patch
     # Set with nullable attributes.
     def self.openapi_nullable
       nullable_properties = Set.new
+
+      nullable_properties.add("create_order")
 
       nullable_properties
     end
@@ -69,6 +75,10 @@ module Patch
 
       if attributes.key?(:'mass_g')
         self.mass_g = attributes[:'mass_g']
+      end
+
+      if attributes.key?(:'create_order')
+        self.create_order = attributes[:'create_order']
       end
 
       if attributes.key?(:'project_id')
@@ -128,6 +138,7 @@ module Patch
       return true if self.equal?(o)
       self.class == o.class &&
           mass_g == o.mass_g &&
+          create_order == o.create_order &&
           project_id == o.project_id
     end
 
@@ -140,7 +151,7 @@ module Patch
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [mass_g, project_id].hash
+      [mass_g, create_order, project_id].hash
     end
 
     # Builds the object from hash

--- a/lib/patch_ruby/models/estimate.rb
+++ b/lib/patch_ruby/models/estimate.rb
@@ -20,8 +20,11 @@ module Patch
     # A boolean indicating if this estimate is a production or test mode estimate.
     attr_accessor :production
 
-    # The type of estimate. Currently mass is the only supported value.
+    # The type of estimate. Available types are mass, flight, shipping, and vehicle.
     attr_accessor :type
+
+    # The estimated mass in grams for this estimate.
+    attr_accessor :mass_g
 
     # An object returning the order associated with this estimate. See the [Order section](/?id=orders) for the full schema.
     attr_accessor :order
@@ -32,6 +35,7 @@ module Patch
         :'id' => :'id',
         :'production' => :'production',
         :'type' => :'type',
+        :'mass_g' => :'mass_g',
         :'order' => :'order'
       }
     end
@@ -42,6 +46,7 @@ module Patch
         :'id' => :'String',
         :'production' => :'Boolean',
         :'type' => :'String',
+        :'mass_g' => :'Integer',
         :'order' => :'Order'
       }
     end
@@ -93,6 +98,10 @@ module Patch
         self.type = attributes[:'type']
       end
 
+      if attributes.key?(:'mass_g')
+        self.mass_g = attributes[:'mass_g']
+      end
+
       if attributes.key?(:'order')
         self.order = attributes[:'order']
       end
@@ -134,6 +143,7 @@ module Patch
           id == o.id &&
           production == o.production &&
           type == o.type &&
+          mass_g == o.mass_g &&
           order == o.order
     end
 
@@ -146,7 +156,7 @@ module Patch
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, production, type, order].hash
+      [id, production, type, mass_g, order].hash
     end
 
     # Builds the object from hash
@@ -239,7 +249,7 @@ module Patch
           is_nullable = self.class.openapi_nullable.include?(attr)
           next if !is_nullable || (is_nullable && !instance_variable_defined?(:"@#{attr}"))
         end
-
+        
         hash[param] = _to_hash(value)
       end
       hash

--- a/lib/patch_ruby/models/photo.rb
+++ b/lib/patch_ruby/models/photo.rb
@@ -70,6 +70,10 @@ module Patch
       if attributes.key?(:'url')
         self.url = attributes[:'url']
       end
+
+      if attributes.key?(:'id')
+        self.id = attributes[:'id']
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?

--- a/lib/patch_ruby/version.rb
+++ b/lib/patch_ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 4.3.1
 =end
 
 module Patch
-  VERSION = '1.2.5'
+  VERSION = '1.2.6'
 end

--- a/lib/patch_ruby/version.rb
+++ b/lib/patch_ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 4.3.1
 =end
 
 module Patch
-  VERSION = '1.2.6'
+  VERSION = '1.3.5'
 end

--- a/lib/patch_ruby/version.rb
+++ b/lib/patch_ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 4.3.1
 =end
 
 module Patch
-  VERSION = '1.3.5'
+  VERSION = '1.3.0'
 end

--- a/spec/integration/estimates_spec.rb
+++ b/spec/integration/estimates_spec.rb
@@ -24,4 +24,47 @@ RSpec.describe 'Estimates Integration' do
 
     expect(estimates.length).not_to be_zero
   end
+
+  it 'supports creating flight estimates' do
+    distance_m = 10_000_000
+    flight_estimate = Patch::Estimate.create_flight_estimate(
+      distance_m: distance_m,
+      create_order: false
+    )
+
+    expect(flight_estimate.data.type).to eq 'flight'
+    expect(flight_estimate.data.mass_g).to eq 1_032_000
+  end
+
+  it 'supports creating vehicle estimates' do
+    distance_m = 10_000
+    make = "Toyota"
+    model = "Prius"
+    year = 2000
+
+    vehicle_estimate = Patch::Estimate.create_vehicle_estimate(
+      distance_m: distance_m,
+      make: make,
+      model: model,
+      year: year,
+      create_order: false
+    )
+
+    expect(vehicle_estimate.data.type).to eq 'vehicle'
+    expect(vehicle_estimate.data.mass_g).to eq 2_132
+  end
+
+  it 'supports creating shipping estimates' do
+    distance_m = 100_000_000
+    package_mass_g = 10_000
+    create_estimate_response = Patch::Estimate.create_shipping_estimate(
+      distance_m: distance_m,
+      package_mass_g: package_mass_g,
+      transportation_method: 'rail',
+      create_order: false
+    )
+
+    expect(create_estimate_response.data.type).to eq 'shipping'
+    expect(create_estimate_response.data.mass_g).to eq 12_431
+  end
 end

--- a/spec/integration/preferences_spec.rb
+++ b/spec/integration/preferences_spec.rb
@@ -10,8 +10,12 @@ RSpec.describe 'Preferences Integration' do
     expect(retrieve_projects_response.data.length).not_to be_zero
     project_id = retrieve_projects_response.data.first.id
 
-    create_preference_response = Patch::Preference.create_preference(project_id: project_id)
-    preference_id = create_preference_response.data.id
+    begin
+      create_preference_response = Patch::Preference.create_preference(project_id: project_id)
+      preference_id = create_preference_response.data.id
+    rescue => Patch::ApiError
+      preference_id = Patch::Preference.retrieve_preferences().data.first.id
+    end
 
     retrieve_preference_response = Patch::Preference.retrieve_preference(preference_id)
     expect(retrieve_preference_response.data.id).to eq preference_id

--- a/spec/models/create_mass_estimate_request_spec.rb
+++ b/spec/models/create_mass_estimate_request_spec.rb
@@ -30,7 +30,7 @@ describe 'CreateMassEstimateRequest' do
   it_behaves_like "a generated class" do
     let(:instance) { @instance }
     let(:instance_hash) { { project_id: @instance.project_id, mass_g: @instance.mass_g } }
-    let(:nullable_properties) { Set.new }
+    let(:nullable_properties) { Set.new(["create_order"]) }
   end
 
   describe 'test an instance of CreateMassEstimateRequest' do


### PR DESCRIPTION
### What

- Adding support for creating Shipping, Vehicle, and Flight estimates 
- Upgrading to v.1.2.6 

### Why

- To extend the Ruby gem to support different kinds of estimates to be created 

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the gem locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [ ] ~~For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?~~ N/A
