### PR TITLE
Use SANDBOX_API_KEY

### DIFF
--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run RSpec
         env:
-          PATCH_RUBY_API_KEY: ${{ secrets.SANDBOX_API_KEY }}
+          SANDBOX_API_KEY: ${{ secrets.SANDBOX_API_KEY }}
         run: bundle exec rspec
 
   failure-notification:


### PR DESCRIPTION
### What

Use `SANDBOX_API_KEY` instead of `PATCH_RUBY_API_KEY`. 

### Why

To make health check tests run properly. 

### SDK Release Checklist

**No release**

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the gem locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
