### PR TITLE
Filter Projects 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Adds Sustainable Development Goals (SDGs) field to projects
+- Adds filtering to Projects by country, type
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ Patch::Estimate.retrieve_estimates(page: page)
 ### Projects
 Projects are the ways Patch takes CO2 out of the air. They can represent reforestation, enhanced weathering, direct air carbon capture, etc. When you place an order via Patch, it is allocated to a project.
 
+When fetching Projects, you can add filters to the query to narrow the result. Currently supported filters are:
+
+- `country`
+- `type`
+
 [API Reference](https://docs.usepatch.com/#/?id=projects)
 
 #### Examples
@@ -155,6 +160,14 @@ Patch::Project.retrieve_project(project_id)
 # Retrieve a list of projects
 page = 1 # Pass in which page of projects you'd like
 Patch::Project.retrieve_projects(page: page)
+
+# Retrieve a all projects from the United States
+country = 'US' # Pass in the country code of the country you'd like to get Projects from
+Patch::Project.retrieve_projects(country: country)
+
+# Retrieve a all biomass projects
+type = 'biomass' # Pass in the type of Projects you'd like to get
+Patch::Project.retrieve_projects(type: type)
 ```
 
 ### Preferences

--- a/lib/patch_ruby/api/projects_api.rb
+++ b/lib/patch_ruby/api/projects_api.rb
@@ -91,7 +91,7 @@ module Patch
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :page 
     # @option opts [String] :country 
-    # @option opts [Integer] :type 
+    # @option opts [String] :type 
     # @return [ProjectListResponse]
     def retrieve_projects(opts = {})
       data, _status_code, _headers = retrieve_projects_with_http_info(opts)
@@ -103,7 +103,7 @@ module Patch
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :page 
     # @option opts [String] :country 
-    # @option opts [Integer] :type 
+    # @option opts [String] :type 
     # @return [Array<(ProjectListResponse, Integer, Hash)>] ProjectListResponse data, response status code and response headers
     def retrieve_projects_with_http_info(opts = {})
       if @api_client.config.debugging

--- a/lib/patch_ruby/api/projects_api.rb
+++ b/lib/patch_ruby/api/projects_api.rb
@@ -90,6 +90,8 @@ module Patch
     # Retrieves a list of projects available for purchase on Patch's platform. 
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :page 
+    # @option opts [String] :country 
+    # @option opts [Integer] :type 
     # @return [ProjectListResponse]
     def retrieve_projects(opts = {})
       data, _status_code, _headers = retrieve_projects_with_http_info(opts)
@@ -100,6 +102,8 @@ module Patch
     # Retrieves a list of projects available for purchase on Patch&#39;s platform. 
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :page 
+    # @option opts [String] :country 
+    # @option opts [Integer] :type 
     # @return [Array<(ProjectListResponse, Integer, Hash)>] ProjectListResponse data, response status code and response headers
     def retrieve_projects_with_http_info(opts = {})
       if @api_client.config.debugging
@@ -111,6 +115,8 @@ module Patch
       # query parameters
       query_params = opts[:query_params] || {}
       query_params[:'page'] = opts[:'page'] if !opts[:'page'].nil?
+      query_params[:'country'] = opts[:'country'] if !opts[:'country'].nil?
+      query_params[:'type'] = opts[:'type'] if !opts[:'type'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/spec/integration/projects_spec.rb
+++ b/spec/integration/projects_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe 'Projects Integration' do
     expect(retrieve_project_response.data.id).to eq project_id
   end
 
+  it 'supports filtering projects' do
+    country = 'US'
+    projects = Patch::Project.retrieve_projects(country: country)
+    projects.data.map do |project|
+      expect(project.country).to eq country
+    end
+
+    type = 'biomass'
+    projects = Patch::Project.retrieve_projects(type: type)
+    projects.data.map do |project|
+      expect(project.type).to eq type
+    end
+  end
+
   describe 'returned fields' do
     before do
       @project = Patch::Project.retrieve_projects(page: 1).data.first

--- a/spec/integration/projects_spec.rb
+++ b/spec/integration/projects_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Projects Integration' do
       expect(project.country).to eq country
     end
 
-    type = 'biomass'
+    type = 'dac'
     projects = Patch::Project.retrieve_projects(type: type)
     projects.data.map do |project|
       expect(project.type).to eq type


### PR DESCRIPTION
### What

- Adds filtering to `retrieve_projects` 

### Why

- So we can get more specific results from the API

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the gem locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
