### PR TITLE
Fix thrown error when calling Patch::Sdg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2021-03-02
+
+### Fixed
+
+- Fixed a `NameError` that was thrown when `Patch::Sdg` was called. Specs have been added to ensure this does not happen again.
+
 ## [1.5.0] - 2021-03-01
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patch_ruby (1.4.0)
+    patch_ruby (1.5.1)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 

--- a/lib/patch_ruby.rb
+++ b/lib/patch_ruby.rb
@@ -36,6 +36,7 @@ require 'patch_ruby/models/preference_response'
 require 'patch_ruby/models/project'
 require 'patch_ruby/models/project_list_response'
 require 'patch_ruby/models/project_response'
+require 'patch_ruby/models/sdg'
 require 'patch_ruby/models/standard'
 
 # APIs

--- a/lib/patch_ruby/version.rb
+++ b/lib/patch_ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 4.3.1
 =end
 
 module Patch
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end

--- a/spec/patch_ruby_spec.rb
+++ b/spec/patch_ruby_spec.rb
@@ -1,0 +1,18 @@
+describe Patch do
+  context 'Models' do
+    it 'defines all models' do
+      constants.each do |constant|
+        expect { Patch.const_get(constant) }.not_to raise_error
+      end
+    end
+  end
+
+  def constants
+    # Given a file path return the constant of that path, for example:
+    # 'lib/patch_ruby/models/project_response.rb' -> ProjectResponse
+    Dir.glob("lib/patch_ruby/models/*.rb").map do |file|
+      parsed_filename = file.split('/').last.split('.').first
+      constant = parsed_filename.split('_').map(&:capitalize).join('')
+    end
+  end
+end


### PR DESCRIPTION
### What

Requiring the SDG model when instantiating the gem. 

### Why

Without this LOC, we get a NameError whenever calling `Patch::Sdg` since it was not required. Tests have been added to make sure that all models present in `lib/patch_ruby/models` are required. 

<details>
<summary>Test run of before/after the fix</summary>

<img width="807" alt="Screen Shot 2021-03-02 at 08 20 47" src="https://user-images.githubusercontent.com/10555255/109681424-4ddf6780-7b32-11eb-9d75-8910a451ad33.png">

</details> 


<details>
<summary>Screenshot of triggering the error in version 1.5.0</summary>

<img width="365" alt="Screen Shot 2021-03-02 at 08 39 47" src="https://user-images.githubusercontent.com/10555255/109682036-e83fab00-7b32-11eb-8a8a-60b6764fc863.png">

</details>

<details>
<summary>Screenshot of triggering the error in version 1.5.1 </summary>
<img width="233" alt="Screen Shot 2021-03-02 at 08 26 52" src="https://user-images.githubusercontent.com/10555255/109681530-6a7b9f80-7b32-11eb-83be-ae12aa343c4e.png">

</details>

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the gem locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
