### PR TITLE
Update parameter validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ build/
 /.openapi-generator/
 
 .byebug_history
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] - 2021-03-30
+
+### Changed
+
+- Updated the value validation for certain parameters to match the API
+- Added the `renewables` type
+
 ## [1.5.1] - 2021-03-02
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patch_ruby (1.5.1)
+    patch_ruby (1.5.2)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
@@ -23,7 +23,7 @@ GEM
       ffi (>= 1.3.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
-    ffi (1.14.2)
+    ffi (1.15.0)
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
@@ -86,4 +86,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.1.4
+   2.2.14

--- a/lib/patch_ruby/models/create_mass_estimate_request.rb
+++ b/lib/patch_ruby/models/create_mass_estimate_request.rb
@@ -98,8 +98,8 @@ module Patch
         invalid_properties.push('invalid value for "mass_g", must be smaller than or equal to 2000000000.')
       end
 
-      if @mass_g < 1
-        invalid_properties.push('invalid value for "mass_g", must be greater than or equal to 1.')
+      if @mass_g < 0
+        invalid_properties.push('invalid value for "mass_g", must be greater than or equal to 0.')
       end
 
       invalid_properties
@@ -110,7 +110,7 @@ module Patch
     def valid?
       return false if @mass_g.nil?
       return false if @mass_g > 2000000000
-      return false if @mass_g < 1
+      return false if @mass_g < 0
       true
     end
 
@@ -125,8 +125,8 @@ module Patch
         fail ArgumentError, 'invalid value for "mass_g", must be smaller than or equal to 2000000000.'
       end
 
-      if mass_g < 1
-        fail ArgumentError, 'invalid value for "mass_g", must be greater than or equal to 1.'
+      if mass_g < 0
+        fail ArgumentError, 'invalid value for "mass_g", must be greater than or equal to 0.'
       end
 
       @mass_g = mass_g

--- a/lib/patch_ruby/models/create_order_request.rb
+++ b/lib/patch_ruby/models/create_order_request.rb
@@ -100,8 +100,8 @@ module Patch
         invalid_properties.push('invalid value for "mass_g", must be smaller than or equal to 2000000000.')
       end
 
-      if !@mass_g.nil? && @mass_g < 1
-        invalid_properties.push('invalid value for "mass_g", must be greater than or equal to 1.')
+      if !@mass_g.nil? && @mass_g < 0
+        invalid_properties.push('invalid value for "mass_g", must be greater than or equal to 0.')
       end
 
       if !@total_price_cents_usd.nil? && @total_price_cents_usd < 1
@@ -115,7 +115,7 @@ module Patch
     # @return true if the model is valid
     def valid?
       return false if !@mass_g.nil? && @mass_g > 2000000000
-      return false if !@mass_g.nil? && @mass_g < 1
+      return false if !@mass_g.nil? && @mass_g < 0
       return false if !@total_price_cents_usd.nil? && @total_price_cents_usd < 1
       true
     end
@@ -127,8 +127,8 @@ module Patch
         fail ArgumentError, 'invalid value for "mass_g", must be smaller than or equal to 2000000000.'
       end
 
-      if !mass_g.nil? && mass_g < 1
-        fail ArgumentError, 'invalid value for "mass_g", must be greater than or equal to 1.'
+      if !mass_g.nil? && mass_g < 0
+        fail ArgumentError, 'invalid value for "mass_g", must be greater than or equal to 0.'
       end
 
       @mass_g = mass_g

--- a/lib/patch_ruby/models/order.rb
+++ b/lib/patch_ruby/models/order.rb
@@ -185,8 +185,8 @@ module Patch
         invalid_properties.push('invalid value for "mass_g", must be smaller than or equal to 2000000000.')
       end
 
-      if @mass_g < 1
-        invalid_properties.push('invalid value for "mass_g", must be greater than or equal to 1.')
+      if @mass_g < 0
+        invalid_properties.push('invalid value for "mass_g", must be greater than or equal to 0.')
       end
 
       if @production.nil?
@@ -218,7 +218,7 @@ module Patch
       return false if @id.nil?
       return false if @mass_g.nil?
       return false if @mass_g > 2000000000
-      return false if @mass_g < 1
+      return false if @mass_g < 0
       return false if @production.nil?
       return false if @state.nil?
       state_validator = EnumAttributeValidator.new('String', ["draft", "placed", "complete", "cancelled"])
@@ -242,8 +242,8 @@ module Patch
         fail ArgumentError, 'invalid value for "mass_g", must be smaller than or equal to 2000000000.'
       end
 
-      if mass_g < 1
-        fail ArgumentError, 'invalid value for "mass_g", must be greater than or equal to 1.'
+      if mass_g < 0
+        fail ArgumentError, 'invalid value for "mass_g", must be greater than or equal to 0.'
       end
 
       @mass_g = mass_g

--- a/lib/patch_ruby/models/project.rb
+++ b/lib/patch_ruby/models/project.rb
@@ -26,7 +26,7 @@ module Patch
     # The description of the project.
     attr_accessor :description
 
-    # The type of carbon removal project, currently available project types are Biomass, Dac, Forestry, Mineralization, Ocean, Soil.
+    # The type of carbon removal project, currently available project types are Biomass, Dac, Forestry, Mineralization, Ocean, Renewables, Soil.
     attr_accessor :type
 
     # The country of origin of the project.
@@ -246,7 +246,7 @@ module Patch
       return false if @production.nil?
       return false if @name.nil?
       return false if @description.nil?
-      type_validator = EnumAttributeValidator.new('String', ["biomass", "dac", "forestry", "mineralization", "ocean", "soil"])
+      type_validator = EnumAttributeValidator.new('String', ["biomass", "dac", "forestry", "mineralization", "ocean", "renewables", "soil"])
       return false unless type_validator.valid?(@type)
       return false if @country.nil?
       return false if @developer.nil?
@@ -258,7 +258,7 @@ module Patch
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] type Object to be assigned
     def type=(type)
-      validator = EnumAttributeValidator.new('String', ["biomass", "dac", "forestry", "mineralization", "ocean", "soil"])
+      validator = EnumAttributeValidator.new('String', ["biomass", "dac", "forestry", "mineralization", "ocean", "renewables", "soil"])
       unless validator.valid?(type)
         fail ArgumentError, "invalid value for \"type\", must be one of #{validator.allowable_values}."
       end

--- a/lib/patch_ruby/version.rb
+++ b/lib/patch_ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 4.3.1
 =end
 
 module Patch
-  VERSION = '1.5.1'
+  VERSION = '1.5.2'
 end

--- a/spec/integration/orders_spec.rb
+++ b/spec/integration/orders_spec.rb
@@ -40,11 +40,12 @@ RSpec.describe 'Orders Integration' do
 
     create_order_response = Patch::Order.create_order(mass_g: order_mass_g, project_id: project_id)
 
+    order = create_order_response.data
     expect(create_order_response.success).to eq true
-    expect(create_order_response.data.id).not_to be_nil
-    expect(create_order_response.data.mass_g).to eq(order_mass_g)
-    expect(create_order_response.data.price_cents_usd.to_i).to eq(expected_price)
-    expect(create_order_response.data.patch_fee_cents_usd).not_to be_empty
+    expect(order.id).not_to be_nil
+    expect(order.mass_g).to eq(order_mass_g)
+    expect(order.price_cents_usd.to_i).to be_between(expected_price - 1, expected_price + 1)
+    expect(order.patch_fee_cents_usd).not_to be_empty
   end
 
   it 'supports create with a total price' do


### PR DESCRIPTION
### What

- Updates default values for the API
- Add the `renewables` project type

### Why

- The allowed query parameter for `total_price_cents_usd` was incorrect and affecting the Python library. This PR brings all libraries on the same base.

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the gem locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
