### PR TITLE
Update types of cents_usd fields in responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2021-07-14
+
+### Changed
+
+- [BREAKING] Changed `order.price_cents_usd` and `order.patch_fee_cents_usd` from string to integer.
+
 ## [1.6.0] - 2021-07-14
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patch_ruby (1.5.2)
+    patch_ruby (1.7.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
@@ -19,11 +19,11 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     diff-lcs (1.4.3)
-    ethon (0.12.0)
-      ffi (>= 1.3.0)
+    ethon (0.14.0)
+      ffi (>= 1.15.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
-    ffi (1.15.0)
+    ffi (1.15.3)
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     json (2.5.1)

--- a/lib/patch_ruby/models/order.rb
+++ b/lib/patch_ruby/models/order.rb
@@ -90,8 +90,8 @@ module Patch
         :'production' => :'Boolean',
         :'state' => :'String',
         :'allocation_state' => :'String',
-        :'price_cents_usd' => :'String',
-        :'patch_fee_cents_usd' => :'String',
+        :'price_cents_usd' => :'Integer',
+        :'patch_fee_cents_usd' => :'Integer',
         :'allocations' => :'Array<Allocation>',
         :'registry_url' => :'String',
         :'metadata' => :'Object'

--- a/lib/patch_ruby/version.rb
+++ b/lib/patch_ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 4.3.1
 =end
 
 module Patch
-  VERSION = '1.6.0'
+  VERSION = '1.7.0'
 end

--- a/spec/integration/orders_spec.rb
+++ b/spec/integration/orders_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe 'Orders Integration' do
     expect(create_order_response.success).to eq true
     expect(order.id).not_to be_nil
     expect(order.mass_g).to eq(order_mass_g)
-    expect(order.price_cents_usd.to_i).to be_between(expected_price - 2, expected_price + 2)
-    expect(order.patch_fee_cents_usd).not_to be_empty
+    expect(order.price_cents_usd).to be_between(expected_price - 2, expected_price + 2)
+    expect(order.patch_fee_cents_usd).to be_kind_of(Integer)
     expect(order.registry_url).not_to be_empty
   end
 
@@ -55,7 +55,7 @@ RSpec.describe 'Orders Integration' do
     )
 
     project_id = retrieve_project_response.data.id
-    total_price_cents_usd = 5_00
+    total_price_cents_usd = 50_00
 
     create_order_response = Patch::Order.create_order(
       total_price_cents_usd: total_price_cents_usd,
@@ -67,13 +67,7 @@ RSpec.describe 'Orders Integration' do
     order = create_order_response.data
 
     expect(order.id).not_to be_nil
-    expect(order.mass_g).to be > 450_000
-    expect(order.mass_g).to be < 460_000
-    expect(order.price_cents_usd).not_to be_empty
-    expect(order.patch_fee_cents_usd).not_to be_empty
-    expect(
-      order.price_cents_usd.to_i + order.patch_fee_cents_usd.to_i
-    ).to eq(total_price_cents_usd)
+    expect(order.price_cents_usd + order.patch_fee_cents_usd).to eq total_price_cents_usd
     expect(order.registry_url).not_to be_empty
   end
 


### PR DESCRIPTION
### What

- Update `order.price_cents_usd` and `order.patch_fee_cents_usd` from string to integer

### Why

- An integer value is more natural and directly usable by a consumer of the API

### Notes

- This version can be released even before the API update since the javascript type conversion is pretty friendly. With the current API version it coerces the string nicely to integer.

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the gem locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [x] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
