### PR TITLE
Notify on failure only

### DIFF
--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Notify slack
         uses: kpritam/slack-job-status-action@v1
         with:
-          if: ${{ always() }}
+          if: ${{ failure() }}
           job-status: ${{ job.status }}
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel: github-actions
+          channel: eng-notifications


### PR DESCRIPTION
### What

- Notify only on failure

### Notes

- I had switched to `always` in a prior commit but mistakenly pushed to main directly (after which I activated the "Include administrators" option of the branch protection)

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the gem locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
