### PR TITLE
Adds deployment notifications

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,20 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    env:
+      TARGET_URL: https://rubygems.org/gems/patch_ruby
+
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+
+      - uses: chrnorm/deployment-action@releases/v1
+        name: Create GitHub deployment
+        id: deployment
+        with:
+          token: "${{ github.token }}"
+          target_url: ${{ env.TARGET_URL }}
+          environment: production
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -32,3 +43,20 @@ jobs:
           GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
         run: gem push patch_ruby.gem
 
+      - name: Update deployment status (success)
+        if: success()
+        uses: chrnorm/deployment-status@releases/v1
+        with:
+          token: "${{ github.token }}"
+          target_url: ${{ env.TARGET_URL }}
+          state: "success"
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status (failure)
+        if: failure()
+        uses: chrnorm/deployment-status@releases/v1
+        with:
+          token: "${{ github.token }}"
+          target_url: ${{ env.TARGET_URL }}
+          state: "failure"
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patch_ruby (1.10.1)
+    patch_ruby (1.10.2)
       typhoeus (~> 1.0, >= 1.0.1)
 
 GEM
@@ -22,7 +22,7 @@ GEM
       ffi (>= 1.15.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
-    ffi (1.15.3)
+    ffi (1.15.4)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)

--- a/lib/patch_ruby/api_client.rb
+++ b/lib/patch_ruby/api_client.rb
@@ -31,7 +31,7 @@ module Patch
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "patch-ruby/1.10.1"
+      @user_agent = "patch-ruby/1.10.2"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent

--- a/lib/patch_ruby/version.rb
+++ b/lib/patch_ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 5.2.1
 =end
 
 module Patch
-  VERSION = '1.10.1'
+  VERSION = '1.10.2'
 end


### PR DESCRIPTION
### What

- Creates a GitHub deployment when the `publish` workflow is initiated
- Updates the status of the deployment at the end of the workflow
- This will trigger Slack notifications based on the Slack<>GitHub settings

### Why

- Rely on GitHub<>Slack instead of rolling our own custom notifications. This lets us have different settings for different channels / users/
- Mirror how we notify of other applications

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the gem locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
