### PR TITLE
Add created_at on order response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2021-09-08
+
+### Added
+
+- Adds a `created_at` attribute in all order responses
+
 ## [1.11.1] - 2021-09-07
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patch_ruby (1.11.1)
+    patch_ruby (1.12.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
 GEM

--- a/lib/patch_ruby/api_client.rb
+++ b/lib/patch_ruby/api_client.rb
@@ -31,7 +31,7 @@ module Patch
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "patch-ruby/1.11.1"
+      @user_agent = "patch-ruby/1.12.0"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent

--- a/lib/patch_ruby/models/create_bitcoin_estimate_request.rb
+++ b/lib/patch_ruby/models/create_bitcoin_estimate_request.rb
@@ -41,7 +41,7 @@ module Patch
     # Attribute type mapping.
     def self.openapi_types
       {
-        :'timestamp' => :'String',
+        :'timestamp' => :'Time',
         :'transaction_value_btc_sats' => :'Integer',
         :'project_id' => :'String',
         :'create_order' => :'Boolean'

--- a/lib/patch_ruby/models/order.rb
+++ b/lib/patch_ruby/models/order.rb
@@ -18,6 +18,9 @@ module Patch
     # A unique uid for the record. UIDs will be prepended by ord_prod or ord_test depending on the mode it was created in.
     attr_accessor :id
 
+    # The timestamp at which the order was created
+    attr_accessor :created_at
+
     # The amount of carbon offsets in grams purchased through this order.
     attr_accessor :mass_g
 
@@ -71,6 +74,7 @@ module Patch
     def self.attribute_map
       {
         :'id' => :'id',
+        :'created_at' => :'created_at',
         :'mass_g' => :'mass_g',
         :'production' => :'production',
         :'state' => :'state',
@@ -92,6 +96,7 @@ module Patch
     def self.openapi_types
       {
         :'id' => :'String',
+        :'created_at' => :'Time',
         :'mass_g' => :'Integer',
         :'production' => :'Boolean',
         :'state' => :'String',
@@ -141,6 +146,10 @@ module Patch
 
       if attributes.key?(:'id')
         self.id = attributes[:'id']
+      end
+
+      if attributes.key?(:'created_at')
+        self.created_at = attributes[:'created_at']
       end
 
       if attributes.key?(:'mass_g')
@@ -288,6 +297,7 @@ module Patch
       return true if self.equal?(o)
       self.class == o.class &&
           id == o.id &&
+          created_at == o.created_at &&
           mass_g == o.mass_g &&
           production == o.production &&
           state == o.state &&
@@ -308,7 +318,7 @@ module Patch
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, mass_g, production, state, allocation_state, price_cents_usd, patch_fee_cents_usd, allocations, registry_url, metadata].hash
+      [id, created_at, mass_g, production, state, allocation_state, price_cents_usd, patch_fee_cents_usd, allocations, registry_url, metadata].hash
     end
 
     # Builds the object from hash

--- a/lib/patch_ruby/version.rb
+++ b/lib/patch_ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 5.2.1
 =end
 
 module Patch
-  VERSION = '1.11.1'
+  VERSION = '1.12.0'
 end

--- a/spec/integration/orders_spec.rb
+++ b/spec/integration/orders_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe 'Orders Integration' do
     order = create_order_response.data
     expect(create_order_response.success).to eq true
     expect(order.id).not_to be_nil
+    expect(order.created_at).to be_a_kind_of(Time)
     expect(order.mass_g).to eq(order_mass_g)
     expect(order.price_cents_usd).to be_between(expected_price - 2, expected_price + 2)
     expect(order.patch_fee_cents_usd).to be_kind_of(Integer)


### PR DESCRIPTION
### What

- Surface the `created_at` field on all order responses

### Why

- For ease of use when retrieving orders

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [ ] Have you built the gem locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
