### PR TITLE
Add average_daily_balance_btc_sats for btc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - 2021-09-10
+
+### Added
+
+- Adds ability to create Bitcoin and Ethereum estimates using the daily balance held.
+
 ## [1.12.0] - 2021-09-08
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patch_ruby (1.12.0)
+    patch_ruby (1.13.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
 GEM

--- a/lib/patch_ruby/api/estimates_api.rb
+++ b/lib/patch_ruby/api/estimates_api.rb
@@ -96,7 +96,7 @@ module Patch
       return data, status_code, headers
     end
 
-    # Create an ethereum estimate given a timestamp and gas used
+    # Create an ethereum estimate
     # Creates an ethereum estimate for the amount of CO2 to be compensated. An order in the `draft` state may be created based on the parameters, linked to the estimate. 
     # @param create_ethereum_estimate_request [CreateEthereumEstimateRequest] 
     # @param [Hash] opts the optional parameters
@@ -107,7 +107,7 @@ module Patch
       data
     end
 
-    # Create an ethereum estimate given a timestamp and gas used
+    # Create an ethereum estimate
     # Creates an ethereum estimate for the amount of CO2 to be compensated. An order in the &#x60;draft&#x60; state may be created based on the parameters, linked to the estimate. 
     # @param create_ethereum_estimate_request [CreateEthereumEstimateRequest] 
     # @param [Hash] opts the optional parameters

--- a/lib/patch_ruby/api_client.rb
+++ b/lib/patch_ruby/api_client.rb
@@ -31,7 +31,7 @@ module Patch
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "patch-ruby/1.12.0"
+      @user_agent = "patch-ruby/1.13.0"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent

--- a/lib/patch_ruby/models/create_bitcoin_estimate_request.rb
+++ b/lib/patch_ruby/models/create_bitcoin_estimate_request.rb
@@ -19,6 +19,8 @@ module Patch
 
     attr_accessor :transaction_value_btc_sats
 
+    attr_accessor :average_daily_balance_btc_sats
+
     attr_accessor :project_id
 
     attr_accessor :create_order
@@ -28,6 +30,7 @@ module Patch
       {
         :'timestamp' => :'timestamp',
         :'transaction_value_btc_sats' => :'transaction_value_btc_sats',
+        :'average_daily_balance_btc_sats' => :'average_daily_balance_btc_sats',
         :'project_id' => :'project_id',
         :'create_order' => :'create_order'
       }
@@ -43,6 +46,7 @@ module Patch
       {
         :'timestamp' => :'Time',
         :'transaction_value_btc_sats' => :'Integer',
+        :'average_daily_balance_btc_sats' => :'Integer',
         :'project_id' => :'String',
         :'create_order' => :'Boolean'
       }
@@ -53,6 +57,7 @@ module Patch
       Set.new([
         :'timestamp',
         :'transaction_value_btc_sats',
+        :'average_daily_balance_btc_sats',
         :'project_id',
         :'create_order'
       ])
@@ -93,12 +98,18 @@ module Patch
         self.transaction_value_btc_sats = attributes[:'transaction_value_btc_sats']
       end
 
+      if attributes.key?(:'average_daily_balance_btc_sats')
+        self.average_daily_balance_btc_sats = attributes[:'average_daily_balance_btc_sats']
+      end
+
       if attributes.key?(:'project_id')
         self.project_id = attributes[:'project_id']
       end
 
       if attributes.key?(:'create_order')
         self.create_order = attributes[:'create_order']
+      else
+        self.create_order = false
       end
     end
 
@@ -122,6 +133,7 @@ module Patch
       self.class == o.class &&
           timestamp == o.timestamp &&
           transaction_value_btc_sats == o.transaction_value_btc_sats &&
+          average_daily_balance_btc_sats == o.average_daily_balance_btc_sats &&
           project_id == o.project_id &&
           create_order == o.create_order
     end
@@ -135,7 +147,7 @@ module Patch
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [timestamp, transaction_value_btc_sats, project_id, create_order].hash
+      [timestamp, transaction_value_btc_sats, average_daily_balance_btc_sats, project_id, create_order].hash
     end
 
     # Builds the object from hash

--- a/lib/patch_ruby/models/create_ethereum_estimate_request.rb
+++ b/lib/patch_ruby/models/create_ethereum_estimate_request.rb
@@ -21,6 +21,8 @@ module Patch
 
     attr_accessor :transaction_value_eth_gwei
 
+    attr_accessor :average_daily_balance_eth_gwei
+
     attr_accessor :project_id
 
     attr_accessor :create_order
@@ -31,6 +33,7 @@ module Patch
         :'timestamp' => :'timestamp',
         :'gas_used' => :'gas_used',
         :'transaction_value_eth_gwei' => :'transaction_value_eth_gwei',
+        :'average_daily_balance_eth_gwei' => :'average_daily_balance_eth_gwei',
         :'project_id' => :'project_id',
         :'create_order' => :'create_order'
       }
@@ -47,6 +50,7 @@ module Patch
         :'timestamp' => :'String',
         :'gas_used' => :'Integer',
         :'transaction_value_eth_gwei' => :'Integer',
+        :'average_daily_balance_eth_gwei' => :'Integer',
         :'project_id' => :'String',
         :'create_order' => :'Boolean'
       }
@@ -58,6 +62,7 @@ module Patch
         :'timestamp',
         :'gas_used',
         :'transaction_value_eth_gwei',
+        :'average_daily_balance_eth_gwei',
         :'project_id',
         :'create_order'
       ])
@@ -102,12 +107,18 @@ module Patch
         self.transaction_value_eth_gwei = attributes[:'transaction_value_eth_gwei']
       end
 
+      if attributes.key?(:'average_daily_balance_eth_gwei')
+        self.average_daily_balance_eth_gwei = attributes[:'average_daily_balance_eth_gwei']
+      end
+
       if attributes.key?(:'project_id')
         self.project_id = attributes[:'project_id']
       end
 
       if attributes.key?(:'create_order')
         self.create_order = attributes[:'create_order']
+      else
+        self.create_order = false
       end
     end
 
@@ -132,6 +143,7 @@ module Patch
           timestamp == o.timestamp &&
           gas_used == o.gas_used &&
           transaction_value_eth_gwei == o.transaction_value_eth_gwei &&
+          average_daily_balance_eth_gwei == o.average_daily_balance_eth_gwei &&
           project_id == o.project_id &&
           create_order == o.create_order
     end
@@ -145,7 +157,7 @@ module Patch
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [timestamp, gas_used, transaction_value_eth_gwei, project_id, create_order].hash
+      [timestamp, gas_used, transaction_value_eth_gwei, average_daily_balance_eth_gwei, project_id, create_order].hash
     end
 
     # Builds the object from hash

--- a/lib/patch_ruby/models/create_flight_estimate_request.rb
+++ b/lib/patch_ruby/models/create_flight_estimate_request.rb
@@ -135,6 +135,8 @@ module Patch
 
       if attributes.key?(:'create_order')
         self.create_order = attributes[:'create_order']
+      else
+        self.create_order = false
       end
     end
 

--- a/lib/patch_ruby/models/create_mass_estimate_request.rb
+++ b/lib/patch_ruby/models/create_mass_estimate_request.rb
@@ -84,6 +84,8 @@ module Patch
 
       if attributes.key?(:'create_order')
         self.create_order = attributes[:'create_order']
+      else
+        self.create_order = false
       end
 
       if attributes.key?(:'project_id')

--- a/lib/patch_ruby/models/create_shipping_estimate_request.rb
+++ b/lib/patch_ruby/models/create_shipping_estimate_request.rb
@@ -127,6 +127,8 @@ module Patch
 
       if attributes.key?(:'create_order')
         self.create_order = attributes[:'create_order']
+      else
+        self.create_order = false
       end
     end
 

--- a/lib/patch_ruby/models/create_vehicle_estimate_request.rb
+++ b/lib/patch_ruby/models/create_vehicle_estimate_request.rb
@@ -116,6 +116,8 @@ module Patch
 
       if attributes.key?(:'create_order')
         self.create_order = attributes[:'create_order']
+      else
+        self.create_order = false
       end
     end
 

--- a/lib/patch_ruby/version.rb
+++ b/lib/patch_ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 5.2.1
 =end
 
 module Patch
-  VERSION = '1.12.0'
+  VERSION = '1.13.0'
 end

--- a/spec/integration/estimates_spec.rb
+++ b/spec/integration/estimates_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Estimates Integration' do
 
 
   it 'supports creating bitcoin estimates with partial information' do
-    bitcoin_estimate = Patch::Estimate.create_bitcoin_estimate({})
+    bitcoin_estimate = Patch::Estimate.create_bitcoin_estimate()
 
     expect(bitcoin_estimate.data.type).to eq 'bitcoin'
     expect(bitcoin_estimate.data.mass_g).to be >= 2_000
@@ -122,6 +122,19 @@ RSpec.describe 'Estimates Integration' do
 
     expect(bitcoin_estimate_1.data.type).to eq 'bitcoin'
     expect(bitcoin_estimate_1.data.mass_g).to be > bitcoin_estimate_2.data.mass_g # Bitcoin was emitting less in July 2021 than in June
+  end
+
+  it 'supports creating bitcoin estimates with a average_daily_balance_btc_sats' do
+    bitcoin_estimate_1 = Patch::Estimate.create_bitcoin_estimate(
+      average_daily_balance_btc_sats: 1000000
+    )
+
+    bitcoin_estimate_2 = Patch::Estimate.create_bitcoin_estimate(
+      average_daily_balance_btc_sats: 10000000
+    )
+
+    expect(bitcoin_estimate_1.data.type).to eq 'bitcoin'
+    expect(bitcoin_estimate_1.data.mass_g).to be < bitcoin_estimate_2.data.mass_g
   end
 
   it 'supports creating ethereum estimates with a gas amount' do

--- a/spec/integration/orders_spec.rb
+++ b/spec/integration/orders_spec.rb
@@ -87,13 +87,13 @@ RSpec.describe 'Orders Integration' do
   end
 
   it 'supports place and cancel for orders created via an estimate' do
-    create_estimate_to_place_response = Patch::Estimate.create_mass_estimate(mass_g: 100)
+    create_estimate_to_place_response = Patch::Estimate.create_mass_estimate(mass_g: 100, create_order: true)
     order_to_place_id = create_estimate_to_place_response.data.order.id
 
     place_order_response = Patch::Order.place_order(order_to_place_id)
     expect(place_order_response.data.state).to eq 'placed'
 
-    create_estimate_to_cancel_response = Patch::Estimate.create_mass_estimate(mass_g: 100)
+    create_estimate_to_cancel_response = Patch::Estimate.create_mass_estimate(mass_g: 100, create_order: true)
     order_to_cancel_id = create_estimate_to_cancel_response.data.order.id
 
     cancel_order_response = Patch::Order.cancel_order(order_to_cancel_id)

--- a/spec/models/create_mass_estimate_request_spec.rb
+++ b/spec/models/create_mass_estimate_request_spec.rb
@@ -29,7 +29,7 @@ describe 'CreateMassEstimateRequest' do
 
   it_behaves_like "a generated class" do
     let(:instance) { @instance }
-    let(:instance_hash) { { project_id: @instance.project_id, mass_g: @instance.mass_g } }
+    let(:instance_hash) { { project_id: @instance.project_id, mass_g: @instance.mass_g, create_order: @instance.create_order } }
     let(:nullable_properties) { Set.new([:create_order]) }
   end
 


### PR DESCRIPTION
### What

- Support for `average_daily_balance` estimates for BTC and ETH

### Why

- Adds a different way to estimate crypto emissions

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [ ] Have you built the gem locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
