### PR TITLE
Update to make the order allocations array optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2022-01-11
+
+### Changed
+
+- Set the order allocatations array as optional.
+
 ## [1.16.1] - 2022-01-07
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patch_ruby (1.16.1)
+    patch_ruby (1.17.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
 GEM
@@ -22,7 +22,7 @@ GEM
       ffi (>= 1.15.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
-    ffi (1.15.4)
+    ffi (1.15.5)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
@@ -71,6 +71,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  arm64-darwin-21
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/lib/patch_ruby/api_client.rb
+++ b/lib/patch_ruby/api_client.rb
@@ -31,7 +31,7 @@ module Patch
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "patch-ruby/1.16.1"
+      @user_agent = "patch-ruby/1.17.0"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent

--- a/lib/patch_ruby/models/order.rb
+++ b/lib/patch_ruby/models/order.rb
@@ -39,7 +39,7 @@ module Patch
     # The Patch Fee in cents USD for this order.
     attr_accessor :patch_fee_cents_usd
 
-    # An array containing the inventory allocations for this order.
+    # DEPRECATED. An array containing the inventory allocations for this order.
     attr_accessor :allocations
 
     # The url of this order in the public registry.
@@ -223,10 +223,6 @@ module Patch
         invalid_properties.push('invalid value for "allocation_state", allocation_state cannot be nil.')
       end
 
-      if @allocations.nil?
-        invalid_properties.push('invalid value for "allocations", allocations cannot be nil.')
-      end
-
       if @metadata.nil?
         invalid_properties.push('invalid value for "metadata", metadata cannot be nil.')
       end
@@ -248,7 +244,6 @@ module Patch
       return false if @allocation_state.nil?
       allocation_state_validator = EnumAttributeValidator.new('String', ["pending", "allocated"])
       return false unless allocation_state_validator.valid?(@allocation_state)
-      return false if @allocations.nil?
       return false if @metadata.nil?
       true
     end

--- a/lib/patch_ruby/models/project.rb
+++ b/lib/patch_ruby/models/project.rb
@@ -27,7 +27,7 @@ module Patch
     # The description of the project.
     attr_accessor :description
 
-    # Deprecated. Favor the technology_type field instead.
+    # DEPRECATED. Favor the technology_type field instead.
     attr_accessor :type
 
     # The mechanism of the project. Either removal or avoidance.

--- a/lib/patch_ruby/version.rb
+++ b/lib/patch_ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 5.3.1
 =end
 
 module Patch
-  VERSION = '1.16.1'
+  VERSION = '1.17.0'
 end


### PR DESCRIPTION
### What

* Changing the order allocations array to be optional

### Why

* Allocations will not always be available for an order

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the gem locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version [in the code generator](https://github.com/patch-technology/client-code-generation/blob/main/configs/ruby-config.json#L11-L12)?
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
