### PR TITLE
1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.0] - 2022-03-22
+### Changed
+
+- Adds optional `state` field to `order` creation
+
 ## [1.17.0] - 2022-01-11
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patch_ruby (1.17.1)
+    patch_ruby (1.18.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
 GEM

--- a/lib/patch_ruby/api/orders_api.rb
+++ b/lib/patch_ruby/api/orders_api.rb
@@ -92,7 +92,7 @@ module Patch
     end
 
     # Creates an order
-    # Creates an order in the `placed` state. To create a `draft` order, create an estimate first. 
+    # Creates an order in the `placed` or `draft` state. 
     # @param create_order_request [CreateOrderRequest] 
     # @param [Hash] opts the optional parameters
     # @return [OrderResponse]
@@ -103,7 +103,7 @@ module Patch
     end
 
     # Creates an order
-    # Creates an order in the &#x60;placed&#x60; state. To create a &#x60;draft&#x60; order, create an estimate first. 
+    # Creates an order in the &#x60;placed&#x60; or &#x60;draft&#x60; state. 
     # @param create_order_request [CreateOrderRequest] 
     # @param [Hash] opts the optional parameters
     # @return [Array<(OrderResponse, Integer, Hash)>] OrderResponse data, response status code and response headers

--- a/lib/patch_ruby/api_client.rb
+++ b/lib/patch_ruby/api_client.rb
@@ -31,7 +31,7 @@ module Patch
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "patch-ruby/1.17.1"
+      @user_agent = "patch-ruby/1.18.0"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent

--- a/lib/patch_ruby/models/create_order_request.rb
+++ b/lib/patch_ruby/models/create_order_request.rb
@@ -23,13 +23,38 @@ module Patch
 
     attr_accessor :metadata
 
+    attr_accessor :state
+
+    class EnumAttributeValidator
+      attr_reader :datatype
+      attr_reader :allowable_values
+
+      def initialize(datatype, allowable_values)
+        @allowable_values = allowable_values.map do |value|
+          case datatype.to_s
+          when /Integer/i
+            value.to_i
+          when /Float/i
+            value.to_f
+          else
+            value
+          end
+        end
+      end
+
+      def valid?(value)
+        !value || allowable_values.include?(value)
+      end
+    end
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         :'mass_g' => :'mass_g',
         :'total_price_cents_usd' => :'total_price_cents_usd',
         :'project_id' => :'project_id',
-        :'metadata' => :'metadata'
+        :'metadata' => :'metadata',
+        :'state' => :'state'
       }
     end
 
@@ -44,7 +69,8 @@ module Patch
         :'mass_g' => :'Integer',
         :'total_price_cents_usd' => :'Integer',
         :'project_id' => :'String',
-        :'metadata' => :'Object'
+        :'metadata' => :'Object',
+        :'state' => :'String'
       }
     end
 
@@ -96,6 +122,10 @@ module Patch
       if attributes.key?(:'metadata')
         self.metadata = attributes[:'metadata']
       end
+
+      if attributes.key?(:'state')
+        self.state = attributes[:'state']
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -123,6 +153,8 @@ module Patch
       return false if !@mass_g.nil? && @mass_g > 100000000000
       return false if !@mass_g.nil? && @mass_g < 0
       return false if !@total_price_cents_usd.nil? && @total_price_cents_usd < 1
+      state_validator = EnumAttributeValidator.new('String', ["draft", "placed"])
+      return false unless state_validator.valid?(@state)
       true
     end
 
@@ -150,6 +182,16 @@ module Patch
       @total_price_cents_usd = total_price_cents_usd
     end
 
+    # Custom attribute writer method checking allowed values (enum).
+    # @param [Object] state Object to be assigned
+    def state=(state)
+      validator = EnumAttributeValidator.new('String', ["draft", "placed"])
+      unless validator.valid?(state)
+        fail ArgumentError, "invalid value for \"state\", must be one of #{validator.allowable_values}."
+      end
+      @state = state
+    end
+
     # Checks equality by comparing each attribute.
     # @param [Object] Object to be compared
     def ==(o)
@@ -158,7 +200,8 @@ module Patch
           mass_g == o.mass_g &&
           total_price_cents_usd == o.total_price_cents_usd &&
           project_id == o.project_id &&
-          metadata == o.metadata
+          metadata == o.metadata &&
+          state == o.state
     end
 
     # @see the `==` method
@@ -170,7 +213,7 @@ module Patch
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [mass_g, total_price_cents_usd, project_id, metadata].hash
+      [mass_g, total_price_cents_usd, project_id, metadata, state].hash
     end
 
     # Builds the object from hash

--- a/lib/patch_ruby/version.rb
+++ b/lib/patch_ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 5.3.1
 =end
 
 module Patch
-  VERSION = '1.17.1'
+  VERSION = '1.18.0'
 end

--- a/spec/integration/orders_spec.rb
+++ b/spec/integration/orders_spec.rb
@@ -84,7 +84,17 @@ RSpec.describe 'Orders Integration' do
       .to all(have_key(:user))
   end
 
-  it 'supports place and cancel for orders created via an estimate' do
+  it 'supports creation in draft state' do
+    create_order_response =
+      Patch::Order.create_order(mass_g: 100, state: "draft")
+
+    expect(create_order_response.success).to eq true
+    expect(create_order_response.data.id).not_to be_nil
+    expect(create_order_response.data.mass_g).to eq(100)
+    expect(create_order_response.data.state).to eq("draft")
+  end
+
+  xit 'supports place and cancel for orders created via an estimate' do
     create_estimate_to_place_response = Patch::Estimate.create_mass_estimate(mass_g: 100, create_order: true)
     order_to_place_id = create_estimate_to_place_response.data.order.id
 


### PR DESCRIPTION
### What

Relates to: https://github.com/patch-technology/patch/pull/1727

- bump to 1.18.0

### Why

- enables draft orders via SDK
- 
### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the gem locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version [in the code generator](https://github.com/patch-technology/client-code-generation/blob/main/configs/ruby-config.json#L11-L12)?
- [ ] If endpoints were removed, did you manually remove the corresponding files? (this should be rare)
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
