### PR TITLE
Re-enable draft cancellation spec

### DIFF
--- a/spec/integration/orders_spec.rb
+++ b/spec/integration/orders_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'Orders Integration' do
     expect(create_order_response.data.state).to eq("draft")
   end
 
-  xit 'supports place and cancel for orders created via an estimate' do
+  it 'supports place and cancel for orders created via an estimate' do
     create_estimate_to_place_response = Patch::Estimate.create_mass_estimate(mass_g: 100, create_order: true)
     order_to_place_id = create_estimate_to_place_response.data.order.id
 


### PR DESCRIPTION
Asana: https://app.asana.com/0/1201614307113702/1202009391127890/f

### What

- Re-enable draft cancellation spec

### Why

- spec coverage for sdk

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the gem locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version [in the code generator](https://github.com/patch-technology/client-code-generation/blob/main/configs/ruby-config.json#L11-L12)?
- [ ] If endpoints were removed, did you manually remove the corresponding files? (this should be rare)
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
