### PR TITLE
1.20.0 - create order by vintage year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2022-04-18
+
+### Added
+
+- Adds optional `vintage_year` field to `order` creation
+
 ## [1.19.0] - 2022-04-05
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    patch_ruby (1.19.0)
+    patch_ruby (1.20.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
 GEM

--- a/lib/patch_ruby/api_client.rb
+++ b/lib/patch_ruby/api_client.rb
@@ -31,7 +31,7 @@ module Patch
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "patch-ruby/1.19.0"
+      @user_agent = "patch-ruby/1.20.0"
       @default_headers = {
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent

--- a/lib/patch_ruby/models/create_order_request.rb
+++ b/lib/patch_ruby/models/create_order_request.rb
@@ -25,6 +25,8 @@ module Patch
 
     attr_accessor :state
 
+    attr_accessor :vintage_year
+
     class EnumAttributeValidator
       attr_reader :datatype
       attr_reader :allowable_values
@@ -54,7 +56,8 @@ module Patch
         :'total_price_cents_usd' => :'total_price_cents_usd',
         :'project_id' => :'project_id',
         :'metadata' => :'metadata',
-        :'state' => :'state'
+        :'state' => :'state',
+        :'vintage_year' => :'vintage_year'
       }
     end
 
@@ -70,13 +73,20 @@ module Patch
         :'total_price_cents_usd' => :'Integer',
         :'project_id' => :'String',
         :'metadata' => :'Object',
-        :'state' => :'String'
+        :'state' => :'String',
+        :'vintage_year' => :'Integer'
       }
     end
 
     # List of attributes with nullable: true
     def self.openapi_nullable
       Set.new([
+        :'mass_g',
+        :'total_price_cents_usd',
+        :'project_id',
+        :'metadata',
+        :'state',
+        :'vintage_year'
       ])
     end
 
@@ -126,6 +136,10 @@ module Patch
       if attributes.key?(:'state')
         self.state = attributes[:'state']
       end
+
+      if attributes.key?(:'vintage_year')
+        self.vintage_year = attributes[:'vintage_year']
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -144,6 +158,14 @@ module Patch
         invalid_properties.push('invalid value for "total_price_cents_usd", must be greater than or equal to 1.')
       end
 
+      if !@vintage_year.nil? && @vintage_year > 2100
+        invalid_properties.push('invalid value for "vintage_year", must be smaller than or equal to 2100.')
+      end
+
+      if !@vintage_year.nil? && @vintage_year < 1900
+        invalid_properties.push('invalid value for "vintage_year", must be greater than or equal to 1900.')
+      end
+
       invalid_properties
     end
 
@@ -155,6 +177,8 @@ module Patch
       return false if !@total_price_cents_usd.nil? && @total_price_cents_usd < 1
       state_validator = EnumAttributeValidator.new('String', ["draft", "placed"])
       return false unless state_validator.valid?(@state)
+      return false if !@vintage_year.nil? && @vintage_year > 2100
+      return false if !@vintage_year.nil? && @vintage_year < 1900
       true
     end
 
@@ -192,6 +216,20 @@ module Patch
       @state = state
     end
 
+    # Custom attribute writer method with validation
+    # @param [Object] vintage_year Value to be assigned
+    def vintage_year=(vintage_year)
+      if !vintage_year.nil? && vintage_year > 2100
+        fail ArgumentError, 'invalid value for "vintage_year", must be smaller than or equal to 2100.'
+      end
+
+      if !vintage_year.nil? && vintage_year < 1900
+        fail ArgumentError, 'invalid value for "vintage_year", must be greater than or equal to 1900.'
+      end
+
+      @vintage_year = vintage_year
+    end
+
     # Checks equality by comparing each attribute.
     # @param [Object] Object to be compared
     def ==(o)
@@ -201,7 +239,8 @@ module Patch
           total_price_cents_usd == o.total_price_cents_usd &&
           project_id == o.project_id &&
           metadata == o.metadata &&
-          state == o.state
+          state == o.state &&
+          vintage_year == o.vintage_year
     end
 
     # @see the `==` method
@@ -213,7 +252,7 @@ module Patch
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [mass_g, total_price_cents_usd, project_id, metadata, state].hash
+      [mass_g, total_price_cents_usd, project_id, metadata, state, vintage_year].hash
     end
 
     # Builds the object from hash

--- a/lib/patch_ruby/version.rb
+++ b/lib/patch_ruby/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 5.3.1
 =end
 
 module Patch
-  VERSION = '1.19.0'
+  VERSION = '1.20.0'
 end

--- a/spec/integration/orders_spec.rb
+++ b/spec/integration/orders_spec.rb
@@ -107,4 +107,13 @@ RSpec.describe 'Orders Integration' do
     cancel_order_response = Patch::Order.cancel_order(order_to_cancel_id)
     expect(cancel_order_response.data.state).to eq 'cancelled'
   end
+
+  it 'supports create with a vintage year' do
+    create_order_response =
+      Patch::Order.create_order(mass_g: 100, vintage_year: 2022)
+
+    expect(create_order_response.success).to eq true
+    expect(create_order_response.data.id).not_to be_nil
+    expect(create_order_response.data.mass_g).to eq(100)
+  end
 end

--- a/spec/models/create_order_request_spec.rb
+++ b/spec/models/create_order_request_spec.rb
@@ -30,7 +30,9 @@ describe 'CreateOrderRequest' do
   it_behaves_like "a generated class" do
     let(:instance) { @instance }
     let(:instance_hash) { { project_id: @instance.project_id, mass_g: @instance.mass_g, total_price_cents_usd: @instance.total_price_cents_usd, metadata: @instance.metadata } }
-    let(:nullable_properties) { Set.new }
+    let(:nullable_properties) do
+      Set.new(%i[mass_g total_price_cents_usd project_id metadata state vintage_year])
+    end
   end
 
   describe 'test an instance of CreateOrderRequest' do


### PR DESCRIPTION
### What

- enabling vintage year to create projects: https://github.com/patch-technology/patch/pull/1864

### Why

- so that users can order a specific vintage year

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the gem locally and made queries against it successfully?
- [x] Did you update the changelog?
- [x] Did you bump the package version [in the code generator](https://github.com/patch-technology/client-code-generation/blob/main/configs/ruby-config.json#L11-L12)?
- [ ] If endpoints were removed, did you manually remove the corresponding files? (this should be rare)
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
