### PR TITLE
Fix test for new demo data

### DIFF
--- a/spec/integration/projects_spec.rb
+++ b/spec/integration/projects_spec.rb
@@ -76,10 +76,10 @@ RSpec.describe 'Projects Integration' do
   it 'retrieves projects in the requested language' do
     projects_response = Patch::Project.retrieve_projects(accept_language: 'fr')
 
-    expect(projects_response.data.first.name).to include 'Projet' # French
+    expect(projects_response.data.first.name).to include 'Démo' # French
 
     project_id = projects_response.data.first.id
     project_response = Patch::Project.retrieve_project(project_id, accept_language: 'fr')
-    expect(project_response.data.name).to include 'Projet' # Frenc
+    expect(project_response.data.name).to include 'Démo' # Frenc
   end
 end


### PR DESCRIPTION
### What

- Fix the test that started failing because of the update to demo projects [Asana](https://app.asana.com/0/1179991099298340/1201390583371221/f)

- Test update only, not triggering a release

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the gem locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version [in the code generator](https://github.com/patch-technology/client-code-generation/blob/main/configs/ruby-config.json#L11-L12)?
- [ ] If endpoints were removed, did you manually remove the corresponding files? (this should be rare)
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
