### PR TITLE
Update activesupport for CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,27 +7,26 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.1)
+    activesupport (7.0.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     ast (2.4.2)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.2.2)
     diff-lcs (1.4.4)
     ethon (0.15.0)
       ffi (>= 1.15.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
     ffi (1.15.5)
-    i18n (1.8.10)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     method_source (1.0.0)
-    minitest (5.14.4)
+    minitest (5.18.0)
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -64,10 +63,9 @@ GEM
     ruby-progressbar (1.11.0)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.5.0)
-    zeitwerk (2.4.2)
 
 PLATFORMS
   arm64-darwin-20
@@ -86,4 +84,4 @@ DEPENDENCIES
   rubocop (~> 0.66.0)
 
 BUNDLED WITH
-   2.2.22
+   2.3.9


### PR DESCRIPTION
### What

Updating `activesupport` gem.

### Why

There are two CVEs open against the current `activesupport` version: https://nvd.nist.gov/vuln/detail/CVE-2023-22796#range-9018819 and https://discuss.rubyonrails.org/t/cve-2023-28120-possible-xss-security-vulnerability-in-safebuffer-bytesplice/82469.
