### PR TITLE
Expect 'ecommerce' estimate type returned instead of deprecated 'ship…

### DIFF
--- a/spec/integration/estimates_spec.rb
+++ b/spec/integration/estimates_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'Estimates Integration' do
       create_order: false
     )
 
-    expect(create_estimate_response.data.type).to eq 'shipping'
+    expect(create_estimate_response.data.type).to eq 'ecommerce'
     expect(create_estimate_response.data.mass_g).to be >= 10_000
   end
 

--- a/spec/integration/projects_spec.rb
+++ b/spec/integration/projects_spec.rb
@@ -74,9 +74,9 @@ RSpec.describe 'Projects Integration' do
   it 'retrieves projects in the requested language' do
     projects_response = Patch::Project.retrieve_projects(accept_language: 'fr')
 
-    expect(projects_response.data.first.name).to include 'Démo' # French
+    expect(projects_response.data.last.name).to include 'Démo' # French
 
-    project_id = projects_response.data.first.id
+    project_id = projects_response.data.last.id
     project_response = Patch::Project.retrieve_project(project_id, accept_language: 'fr')
     expect(project_response.data.name).to include 'Démo' # Frenc
   end


### PR DESCRIPTION
…ping' type

### What
Expect `ecommerce` type in estimate response instead of `shipping` 

### Why
Update test expectation to match deprecated type change in response.

### SDK Release Checklist

- [x] Have you added an integration test for the changes?
- [x] Have you built the gem locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version [in the code generator](https://github.com/patch-technology/client-code-generation/blob/main/configs/ruby-config.json#L11-L12)?
- [ ] If endpoints were removed, did you manually remove the corresponding files? (this should be rare)
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
