### PR TITLE
Expand test matrix to more recent versions of Ruby

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4.3
+          ruby-version: 3.3.6
 
       - name: Build Gem
         run: gem build -o patch_ruby.gem patch_ruby.gemspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.4.3, 3.3.6, 3.1.2, 2.7.4]
+        ruby-version: [3.4.2, 3.3.6, 3.1.2, 2.7.4]
       max-parallel: 4
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.1.2, 3.0.2, 2.7.4]
-      max-parallel: 1
+        ruby-version: [3.4.3, 3.3.6, 3.1.2, 2.7.4]
+      max-parallel: 4
 
     steps:
       - name: Check out code

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
     method_source (1.0.0)
     minitest (5.18.0)
     mutex_m (0.3.0)
+    observer (0.1.2)
     parallel (1.27.0)
     parser (3.3.10.0)
       ast (~> 2.4.1)
@@ -86,6 +87,7 @@ PLATFORMS
 DEPENDENCIES
   factory_bot (~> 6.2)
   mutex_m
+  observer
   patch_ruby!
   pry
   pry-byebug

--- a/patch_ruby.gemspec
+++ b/patch_ruby.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_bot', '~> 6.2'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'mutex_m' # Required for Ruby 3.4+
+  s.add_development_dependency 'observer' # Required for Ruby 3.4+
   # End custom
 
 end


### PR DESCRIPTION
### What

- Add 3.4 and 3.3

### Why

- Find issues with dependencies

### SDK Release Checklist

- [ ] Have you added an integration test for the changes?
- [ ] Have you built the gem locally and made queries against it successfully?
- [ ] Did you update the changelog?
- [ ] Did you bump the package version [in the code generator](https://github.com/patch-technology/client-code-generation/blob/main/configs/ruby-config.json#L11-L12)?
- [ ] If endpoints were removed, did you manually remove the corresponding files? (this should be rare)
- [ ] For breaking changes, did you plan for the release of the new SDK versions and deploy the API to production?
